### PR TITLE
Ensure nll and choice_logprob metrics

### DIFF
--- a/lm_eval/api/metrics.py
+++ b/lm_eval/api/metrics.py
@@ -64,6 +64,12 @@ def bpb(bpb):
     return bpb
 
 
+# Register "nll" metric
+@register_metric(metric="nll", higher_is_better=False, aggregation="mean")
+def nll(nll):
+    return nll
+
+
 # Register "logprob" metric
 @register_metric(metric="logprob", higher_is_better=True, aggregation="mean")
 def logprob(logprob):

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -1553,6 +1553,7 @@ class ConfigurableTask(Task):
             return {
                 **({"perplexity": ll} if "perplexity" in use_metric else {}),
                 **({"acc": int(is_greedy)} if "acc" in use_metric else {}),
+                **({"nll": -ll} if "nll" in use_metric else {}),
             }
         elif self.OUTPUT_TYPE == "loglikelihood_rolling":
             (loglikelihood,) = results
@@ -1574,6 +1575,7 @@ class ConfigurableTask(Task):
                     if "bits_per_byte" in use_metric
                     else {}
                 ),
+                **({"nll": -loglikelihood} if "nll" in use_metric else {}),
             }
         elif self.OUTPUT_TYPE == "multiple_choice":
             lls, is_greedy = zip(*results)

--- a/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_a_yaml
@@ -11,5 +11,6 @@ doc_to_choice: "{{multiple_choice_targets}}"
 metric_list:
   - metric: acc
   # TODO: brier score and other metrics
+  - metric: choice_logprob
 metadata:
   version: 1.0

--- a/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
+++ b/lm_eval/tasks/bigbench/multiple_choice_template_b_yaml
@@ -11,5 +11,6 @@ doc_to_choice: "{{multiple_choice_targets}}"
 metric_list:
   - metric: acc
   # TODO: brier score and other metrics
+  - metric: choice_logprob
 metadata:
   version: 1.0

--- a/lm_eval/tasks/lambada/lambada_standard.yaml
+++ b/lm_eval/tasks/lambada/lambada_standard.yaml
@@ -14,6 +14,9 @@ metric_list:
   - metric: perplexity
     aggregation: perplexity
     higher_is_better: false
+  - metric: nll
+    aggregation: mean
+    higher_is_better: false
   - metric: acc
     aggregation: mean
     higher_is_better: true

--- a/lm_eval/tasks/logiqa/logiqa.yaml
+++ b/lm_eval/tasks/logiqa/logiqa.yaml
@@ -17,6 +17,9 @@ metric_list:
   - metric: acc_norm
     aggregation: mean
     higher_is_better: true
+  - metric: choice_logprob
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 1.0
 dataset_kwargs:

--- a/lm_eval/tasks/pubmedqa/pubmedqa.yaml
+++ b/lm_eval/tasks/pubmedqa/pubmedqa.yaml
@@ -12,5 +12,8 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+  - metric: choice_logprob
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 1.0

--- a/lm_eval/tasks/siqa/siqa.yaml
+++ b/lm_eval/tasks/siqa/siqa.yaml
@@ -12,5 +12,8 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+  - metric: choice_logprob
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 0.0

--- a/lm_eval/tasks/winogender/winogender.yaml
+++ b/lm_eval/tasks/winogender/winogender.yaml
@@ -15,6 +15,9 @@ metric_list:
   - metric: acc
     aggregation: mean
     higher_is_better: true
+  - metric: choice_logprob
+    aggregation: mean
+    higher_is_better: true
 metadata:
   version: 1.0
   num_fewshot: 0


### PR DESCRIPTION
## Summary
- support nll metric in core API
- add nll metric to Lambada standard task
- include choice_logprob in multiple-choice task configs

## Testing
- `pytest` *(fails: Please install unitxt via 'pip install unitxt')*

------
https://chatgpt.com/codex/tasks/task_e_68af68e8e110832296da48ee381b99c4