### PR TITLE
Add GSM8K loss evaluation task

### DIFF
--- a/lm_eval/tasks/gsm8k/README.md
+++ b/lm_eval/tasks/gsm8k/README.md
@@ -46,6 +46,7 @@ Homepage: https://github.com/openai/grade-school-math
 - `gsm8k_cot_self_consistency`: GSM8K with Chain-of-Thought and Self-Consistency
 - `gsm8k_cot_llama`: GSM8K with prompt formatting modified to conform to the evaluation settings described by Meta here: https://huggingface.co/datasets/meta-llama/Meta-Llama-3.1-8B-Instruct-evals/viewer/Meta-Llama-3.1-8B-Instruct-evals__gsm8k__details?row=0
     - Use this task with --fewshot_as_multiturn and --apply_chat_template to replicate Meta's reported performance.
+- `gsm8k_loss`: GSM8K evaluated by the negative log-likelihood of the reference answer
 
 
 ### Checklist

--- a/lm_eval/tasks/gsm8k/gsm8k-loss.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k-loss.yaml
@@ -1,0 +1,17 @@
+tag:
+  - math_word_problems
+task: gsm8k_loss
+dataset_path: gsm8k
+dataset_name: main
+output_type: loglikelihood
+training_split: train
+fewshot_split: train
+test_split: test
+doc_to_text: "Question: {{question}}\nAnswer:"
+doc_to_target: "{{answer}}"
+metric_list:
+  - metric: nll
+    aggregation: mean
+    higher_is_better: false
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/gsm8k/gsm8k-loss.yaml
+++ b/lm_eval/tasks/gsm8k/gsm8k-loss.yaml
@@ -10,7 +10,7 @@ test_split: test
 doc_to_text: "Question: {{question}}\nAnswer:"
 doc_to_target: "{{answer}}"
 metric_list:
-  - metric: nll
+  - metric: bpb
     aggregation: mean
     higher_is_better: false
 metadata:


### PR DESCRIPTION
## Summary
- add GSM8K loss task YAML to compute negative log-likelihood for reference answers
- document GSM8K loss task variant in GSM8K task README

## Testing
- `pytest tests/test_tasks.py::TestNewTasksElseDefault -k gsm8k_loss -q` *(fails: Couldn't reach 'gsm8k' on the Hub (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68c4b2a1656c83289629192733be01ae